### PR TITLE
Update compile and target SDK to 36

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,12 +9,12 @@ plugins {
 
 android {
     namespace = "dev.bacecek.launcher"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "dev.bacecek.launcher"
         minSdk = 24
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
 


### PR DESCRIPTION
## Summary
- bump compileSdk and targetSdk versions to 36

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eef6c4a90832e97b2a634f5048628