### PR TITLE
Refactor icon lookup during app info load

### DIFF
--- a/app/src/main/java/dev/bacecek/launcher/apps/AppIcon.kt
+++ b/app/src/main/java/dev/bacecek/launcher/apps/AppIcon.kt
@@ -1,7 +1,6 @@
 package dev.bacecek.launcher.apps
 
 import android.content.ComponentName
-import android.os.UserHandle
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.combinedClickable
@@ -23,13 +22,11 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
-import dev.bacecek.launcher.di.DI
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -39,7 +36,6 @@ fun AppIcon(
     onAppClicked: (AppInfo) -> Unit,
     onAppLongClicked: (AppInfo) -> Unit,
     isTitleVisible: Boolean,
-    iconCache: AppIconCache = DI.graph.appIconCache,
 ) {
     Box(modifier = modifier, contentAlignment = Alignment.Center) {
         Column(
@@ -53,11 +49,8 @@ fun AppIcon(
                     indication = null,
                 )
         ) {
-            val icon = remember(appInfo.component, appInfo.user) {
-                iconCache.getIcon(appInfo.component, appInfo.user)
-            }
             Image(
-                painter = rememberDrawablePainter(drawable = icon),
+                painter = rememberDrawablePainter(drawable = appInfo.icon),
                 contentDescription = null,
                 modifier = Modifier.size(56.dp),
                 contentScale = ContentScale.Crop,
@@ -98,6 +91,7 @@ private fun AppIconPreview() {
             component = ComponentName("com.example.app", "com.example.app.MainActivity"),
             user = UserHandleUid(0),
             isSystemApp = false,
+            icon = null,
         ),
         onAppClicked = {},
         onAppLongClicked = {},

--- a/app/src/main/java/dev/bacecek/launcher/apps/AppInfo.kt
+++ b/app/src/main/java/dev/bacecek/launcher/apps/AppInfo.kt
@@ -2,6 +2,7 @@ package dev.bacecek.launcher.apps
 
 import android.content.ComponentName
 import androidx.core.os.UserHandleCompat
+import android.graphics.drawable.Drawable
 
 @JvmInline
 value class UserHandleUid(val value: Int)
@@ -13,4 +14,5 @@ data class AppInfo(
     val component: ComponentName,
     val user: UserHandleUid,
     val isSystemApp: Boolean,
+    val icon: Drawable?,
 )

--- a/app/src/main/java/dev/bacecek/launcher/apps/AppsRepository.kt
+++ b/app/src/main/java/dev/bacecek/launcher/apps/AppsRepository.kt
@@ -9,6 +9,7 @@ import android.icu.text.Collator
 import android.os.UserManager
 import dev.bacecek.launcher.BuildConfig
 import dev.bacecek.launcher.di.CoroutineDispatchers
+import dev.bacecek.launcher.apps.AppIconCache
 import dev.bacecek.launcher.utils.GlobalLocaleChangeDispatcher
 import dev.bacecek.launcher.utils.requireSystemService
 import dev.bacecek.launcher.utils.sortedWithCollatorBy
@@ -28,6 +29,7 @@ internal class AppsRepositoryImpl(
     private val coroutineScope: CoroutineScope,
     private val appsEventsDispatcher: AppEventsDispatcher,
     private val localeChangeDispatcher: GlobalLocaleChangeDispatcher,
+    private val iconCache: AppIconCache,
 ) : AppsRepository {
     private val userManager: UserManager by lazy { context.requireSystemService() }
     private val launcherApps: LauncherApps by lazy { context.requireSystemService() }
@@ -73,6 +75,7 @@ internal class AppsRepositoryImpl(
         component = componentName,
         user = UserHandleUid(applicationInfo.uid),
         isSystemApp = applicationInfo.isSystemApp(context),
+        icon = iconCache.getIcon(componentName, UserHandleUid(applicationInfo.uid)),
     )
 
     private fun ApplicationInfo.isSystemApp(context: Context): Boolean {

--- a/app/src/main/java/dev/bacecek/launcher/di/AppGraph.kt
+++ b/app/src/main/java/dev/bacecek/launcher/di/AppGraph.kt
@@ -59,8 +59,9 @@ interface AppGraph {
         scope: CoroutineScope,
         events: AppEventsDispatcher,
         localeChangeDispatcher: GlobalLocaleChangeDispatcher,
+        iconCache: AppIconCache,
     ): AppsRepository =
-        AppsRepositoryImpl(application, dispatchers, scope, events, localeChangeDispatcher)
+        AppsRepositoryImpl(application, dispatchers, scope, events, localeChangeDispatcher, iconCache)
 
     @Provides
     fun provideRecentsRepository(


### PR DESCRIPTION
## Summary
- remove `icon` parameter from `AppIcon` composable
- load icon inside `LauncherActivityInfo.toAppInfo`
- update grid and recent lists to pass only `AppInfo`

## Testing
- `./gradlew assembleDebug --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_6850658f45c0832ea993538789de838b